### PR TITLE
Put Scala binary version in the jar file name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.jesusthecat</groupId>
     <artifactId>jodhpur</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1_${scala.major.version}-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <scala.major.version>2.11</scala.major.version>


### PR DESCRIPTION
as per standard Scala practice, to avoid weird Scala version clashes
suddenly appearing in builds that depend on this jar

Worth noting that this creates a Maven warning in the build, but I don't know how I would avoid that warning other than hardcoding the Scala version, which is bad.