### PR TITLE
Put Scala version in the name *correctly*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.jesusthecat</groupId>
-    <artifactId>jodhpur</artifactId>
-    <version>0.1_${scala.major.version}-SNAPSHOT</version>
+    <artifactId>jodhpur_${scala.major.version}</artifactId>
+    <version>0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <scala.major.version>2.11</scala.major.version>


### PR DESCRIPTION
The last commit put the version in the wrong place. This fixes that.