### PR TITLE
Check that the algorithms (or lack thereof) match

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.jesusthecat</groupId>
     <artifactId>jodhpur_${scala.major.version}</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <scala.major.version>2.11</scala.major.version>

--- a/src/main/scala/com/jesusthecat/jodhpur/CryptoParams.scala
+++ b/src/main/scala/com/jesusthecat/jodhpur/CryptoParams.scala
@@ -1,0 +1,13 @@
+package com.jesusthecat.jodhpur
+
+trait CryptoParams {
+  val algorithm: SigningAlgorithm
+}
+
+case object NoCrypto extends CryptoParams {
+  override val algorithm = NoAlgorithm
+}
+
+case class HasCrypto(secret: Array[Byte],
+  override val algorithm: SigningAlgorithm = HmacSHA256)
+    extends CryptoParams

--- a/src/main/scala/com/jesusthecat/jodhpur/SigningAlgorithm.scala
+++ b/src/main/scala/com/jesusthecat/jodhpur/SigningAlgorithm.scala
@@ -7,8 +7,6 @@ sealed trait SigningAlgorithm {
 
   def key: String
 
-  def supports(that: String): Boolean = key == that
-
   def sign(secret: Array[Byte], bx: Array[Byte]): Array[Byte]
 }
 
@@ -18,7 +16,7 @@ object SigningAlgorithm {
 
   def parse(v: StringOrUri): Option[SigningAlgorithm] = {
     val norm = v.asString.toLowerCase
-    algorithms.find(_.supports(norm))
+    algorithms.find(_.key == norm)
   }
 }
 
@@ -36,9 +34,6 @@ object NoAlgorithm extends SigningAlgorithm {
 object HmacSHA256 extends SigningAlgorithm {
 
   override def key: String = "hs256"
-
-  override def supports(key: String): Boolean =
-    key == "hs256"
 
   override def sign(secret: Array[Byte], bx: Array[Byte]): Array[Byte] = {
     val hmac = Mac.getInstance("HmacSHA256")

--- a/src/test/scala/com/jesusthecat/jodhpur/JWTReaderSpec.scala
+++ b/src/test/scala/com/jesusthecat/jodhpur/JWTReaderSpec.scala
@@ -67,6 +67,11 @@ class JWTReaderSpec
         res should be(Failure(NonEmptyList(JWTReader.MsgSecretRequired)))
       }
 
+      it("should fail if there is no signature, but a secret has been provided") {
+        val res = new JWTReader(specCrypto).read(s"eyJ0eXAiOiJKV1QiLCAiYWxnIjoibm9uZSJ9.eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODB9")
+        res should be(Failure(NonEmptyList(JWTReader.MsgSecretRequired)))
+      }
+
       it("should fail if token is expired") {
         val expiredInstant = Instant.now().minusSeconds(JWTReader.ThresholdSeconds * 2)
         val token = createSignedToken(

--- a/src/test/scala/com/jesusthecat/jodhpur/JWTReaderSpec.scala
+++ b/src/test/scala/com/jesusthecat/jodhpur/JWTReaderSpec.scala
@@ -14,6 +14,7 @@ class JWTReaderSpec
 
   // From the JWS spec. (http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31#section-4.1.1)
   val specSecret = Base64.decodeToBytes("AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow").get
+  val specCrypto = HasCrypto(specSecret)
   // {"typ":"JWT",\n "alg":"HS256"}
   val specHeader = "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"
   // {"iss":"joe",\n "exp":1300819380,\n "http://example.com/is_root":true}
@@ -35,34 +36,34 @@ class JWTReaderSpec
     describe("Validation") {
 
       it("should fail to parse JWT with no periods") {
-        val res = new JWTReader().read("AAAA")
+        val res = new JWTReader(NoCrypto).read("AAAA")
         res should be(Failure(NonEmptyList(JWTReader.MsgCouldntParse)))
       }
 
       it("should fail to parse JWT with three periods") {
-        val res = new JWTReader().read("AAAA.BBBB.CCCC.DDDD")
+        val res = new JWTReader(NoCrypto).read("AAAA.BBBB.CCCC.DDDD")
         res should be(Failure(NonEmptyList(JWTReader.MsgCouldntParse)))
       }
 
       it("should fail if signatures don't match") {
         // Appending arbitrary characters to the signature invalidates it.
-        val res = new JWTReader(secret = Some(specSecret)).read(specToken + "ASDF")
+        val res = new JWTReader(specCrypto).read(specToken + "ASDF")
         res should be(Failure(NonEmptyList(JWTReader.MsgSecretRequired)))
       }
 
       it("should fail if there _is no_ signature") {
-        val res = new JWTReader(secret = Some(specSecret)).read(s"$specHeader.$specClaims")
+        val res = new JWTReader(specCrypto).read(s"$specHeader.$specClaims")
         res should be(Failure(NonEmptyList(JWTReader.MsgSecretRequired)))
       }
 
-      it("should fail if there is no matching algorithm") {
+      it("should fail if there is no recognised algorithm") {
         val noMatchingAlgoHeader = Base64.encode("""{"typ":"JWT", "alg":"FOO"}""")
-        val res = new JWTReader(secret = Some(specSecret)).read(s"$noMatchingAlgoHeader.$specClaims")
+        val res = new JWTReader(specCrypto).read(s"$noMatchingAlgoHeader.$specClaims")
         res.isFailure should be(true)
       }
 
       it("should fail if there is no secret") {
-        val res = new JWTReader(secret = None).read(specToken)
+        val res = new JWTReader(NoCrypto).read(specToken)
         res should be(Failure(NonEmptyList(JWTReader.MsgSecretRequired)))
       }
 
@@ -71,7 +72,7 @@ class JWTReaderSpec
         val token = createSignedToken(
           header = """{"typ":"JWT", "alg":"HS256"}""",
           claims = s"""{"exp":${expiredInstant.getEpochSecond}}""")
-        val res = new JWTReader(secret = Some(specSecret)).read(token)
+        val res = new JWTReader(specCrypto).read(token)
         res should be(Failure(NonEmptyList(JWTReader.MsgExpired)))
       }
 
@@ -80,7 +81,7 @@ class JWTReaderSpec
         val token = createSignedToken(
           header = """{"typ":"JWT", "alg":"HS256"}""",
           claims = s"""{"exp":${expiredInstant.getEpochSecond}}""")
-        val res = new JWTReader(secret = Some(specSecret)).read(token)
+        val res = new JWTReader(specCrypto).read(token)
         res.isSuccess should be(true)
       }
 
@@ -88,7 +89,7 @@ class JWTReaderSpec
         val token = createSignedToken(
           header = """{"typ":"JWT", "alg":"HS256"}""",
           claims = s"""{"iss":"foo"}""")
-        val res = new JWTReader(secret = Some(specSecret), issuer = Some("bar")).read(token)
+        val res = new JWTReader(specCrypto, issuer = Some("bar")).read(token)
         res should be(Failure(NonEmptyList(JWTReader.MsgInvalidIssuer)))
       }
 
@@ -96,7 +97,7 @@ class JWTReaderSpec
         val token = createSignedToken(
           header = """{"typ":"JWT", "alg":"HS256"}""",
           claims = s"""{"aud":"foo"}""")
-        val res = new JWTReader(secret = Some(specSecret), audience = Some("bar")).read(token)
+        val res = new JWTReader(specCrypto, audience = Some("bar")).read(token)
         res should be(Failure(NonEmptyList(JWTReader.MsgInvalidAudience)))
       }
     }
@@ -107,7 +108,7 @@ class JWTReaderSpec
 
       it("should parse Plaintext JWT") {
         val token = "eyJ0eXAiOiJKV1QiLCAiYWxnIjoibm9uZSJ9.eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODB9"
-        val v = new JWTReader(issuer = Some("joe")).read(token)
+        val v = new JWTReader(NoCrypto, issuer = Some("joe")).read(token)
         val UnverifiedJwt(header, claims) = v.toOption.value
         header.alg should be(NoAlgorithm)
         header.typ.value should be("JWT")
@@ -122,7 +123,7 @@ class JWTReaderSpec
       implicit val clock = Clock.fixed(specExpiryInstant, ZoneOffset.UTC)
 
       it("should parse Signed JWT (with known secret)") {
-        val jwt = new JWTReader(secret = Some(specSecret), issuer = Some("joe")).read(specToken)
+        val jwt = new JWTReader(specCrypto, issuer = Some("joe")).read(specToken)
         val VerifiedJwt(header, claims) = jwt.toOption.value
         header.alg should be(HmacSHA256)
         header.typ.value should be("JWT")

--- a/src/test/scala/com/jesusthecat/jodhpur/JWTWriterSpec.scala
+++ b/src/test/scala/com/jesusthecat/jodhpur/JWTWriterSpec.scala
@@ -27,7 +27,7 @@ class JWTWriterSpec
       it("should symmetrically write a JavascriptWebToken") {
         val token = VerifiedJwt(header, claims)
         val encoded = new JWTWriter(Some(secret)).encode(token)
-        val decoded = new JWTReader(secret = Some(secret), issuer = token.claims.iss, audience = token.claims.aud.headOption).read(encoded)
+        val decoded = new JWTReader(HasCrypto(secret), issuer = token.claims.iss, audience = token.claims.aud.headOption).read(encoded)
         decoded.toOption.value should be(VerifiedJwt(token.header, token.claims))
       }
     }
@@ -36,7 +36,7 @@ class JWTWriterSpec
       it("should symmetrically write a JavascriptWebToken") {
         val token = UnverifiedJwt(header.copy(alg = NoAlgorithm), claims)
         val encoded = new JWTWriter().encode(token)
-        val decoded = new JWTReader(issuer = token.claims.iss, audience = token.claims.aud.headOption).read(encoded)
+        val decoded = new JWTReader(NoCrypto, issuer = token.claims.iss, audience = token.claims.aud.headOption).read(encoded)
         decoded.toOption.value should be(UnverifiedJwt(token.header, token.claims))
       }
     }


### PR DESCRIPTION
As a result, the client has to always specify explicitly whether they
want crypto or not, and if so, which algorithm. This is mandatory
because the client programmer must be required to think about it.

This covers two points from the relevant RFCs:
1. secrets must correspond to the right algorithms (currently not a live
   issue because only one non-trivial algorithm is supported - although
   the RFC does allow more than one algorithm to be supported, optionally)
2. unsigned tokens must only be accepted if the application explicitly
   decides to do so. This is the important bit.
